### PR TITLE
Restructure README to be similar to python README document

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,4 +211,4 @@ PACKAGE_DIRECTORY=build
 
 ### License
 
-Apache Software License v2. Copyright © 2014-2020 SignalFx
+Apache Software License v2. Copyright © 2014-2020 Splunk, Inc.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For advanced users (to reduce size of deployment packages):
 
 In this option, you will use a Lambda layer created and hosted by SignalFx.
 
-1. To verify compatibility, review the list of supported regions. See [Lambda Layer Versions](https://github.com/signalfx/lambda-layer-versions/blob/master/nodejs/NODE.md).
+1. To verify compatibility, review the list of supported regions. See [Lambda Layer Versions](https://github.com/signalfx/lambda-layer-versions/blob/master/node/NODE.md).
 2. Open your AWS console. 
 3. In the landing page, under **Compute**, click **Lambda**.
 4. Click **Create function** to create a layer with SignalFx's capabilities.
@@ -42,7 +42,7 @@ In this option, you will use a Lambda layer created and hosted by SignalFx.
 9. Click on **Layers**, then add a layer.
 10. Mark **Provide a layer version**.
 11. Enter an ARN number. 
-  * To locate the ARN number, see [Lambda Layer Versions](https://github.com/signalfx/lambda-layer-versions/blob/master/nodejs/NODE.md).
+  * To locate the ARN number, see [Lambda Layer Versions](https://github.com/signalfx/lambda-layer-versions/blob/master/node/NODE.md).
 
 ### Option 2: Create a Lambda function, then create and attach a layer based on a SignalFx template
 
@@ -59,14 +59,12 @@ In this option, you will choose a SignalFx template, and then deploy a copy of t
 8. Return to the previous screen to add a layer to the function, select from list of runtime compatible layers, and then select the name of the copy. 
 
 ### Option 3: Install the wrapper package with npm
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Run the following installation script in your command line to install latest version of the wrapper:
 
-.. code::
-
-    npm install signalfx-lambda
-    
+```javascript
+npm install signalfx-lambda
+```    
 Make sure the package is saved to your package.json (newer versions of npm do this automatically).
 
 ## Step 2: Locate ingest endpoint
@@ -79,24 +77,22 @@ To locate your realm:
 2. Click **My Profile**.
 3. Next to **Organizations**, review the listed realm.
 
-You will use the endpoint to set SIGNALFX_INGEST_ENDPOINT variable in the next step.
+You will use the realm subdomain to set SIGNALFX_INGEST_ENDPOINT variable in the next step.
 
 ## Step 3: Set environment variables
 
 1. Set SIGNALFX_AUTH_TOKEN with your correct access token. Review the following example. 
-
-```
- SIGNALFX_AUTH_TOKEN=signalfx token
-```
-2. Set the ingest endpoint URL (remember to use appropriate realm):
-
-```
-SIGNALFX_INGEST_ENDPOINT=[https://pops.signalfx.com]
-```
+    ```bash
+     SIGNALFX_AUTH_TOKEN=signalfx token
+    ```
+2. Set the ingest endpoint URL (remember to use correct the domain corresponding to your realm):
+    ```bash
+    SIGNALFX_INGEST_ENDPOINT=[https://pops.signalfx.com]
+    ```
 3. Change SIGNALFX_SEND_TIMEOUT (optional):
-```
-SIGNALFX_SEND_TIMEOUT=milliseconds for signalfx client timeout [1000]
-```
+    ```bash
+    SIGNALFX_SEND_TIMEOUT=milliseconds for signalfx client timeout [1000]
+    ```
 
 ## Step 4: Wrap a function
       

--- a/README.md
+++ b/README.md
@@ -1,23 +1,105 @@
 # SignalFx Node Lambda Wrapper
 
-SignalFx Node Lambda Wrapper.
+## Overview 
 
-## Usage
+You can use this document to add a SignalFx wrapper to your AWS Lambda for Node. 
 
-The SignalFx NodeJS Lambda Wrapper is a wrapper around an AWS Lambda NodeJS function handler, used to instrument execution of the function and send metrics to SignalFx.
+The SignalFx Node Lambda Wrapper wraps around an AWS Lambda Node function handler, which allows metrics to be sent to SignalFx.
 
-### Installation
+At a high-level, to add a SignalFx Node Lambda wrapper, you can package the code yourself, or you can use a Lambda layer containing the wrapper and then attach the layer to a Lambda function.
 
-Use the hosted package:
+To learn more about Lambda Layers, please visit the AWS documentation site and see [AWS Lambda Layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
+
+## Step 1: Add the Lambda wrapper in AWS
+
+To add the SignalFx wrapper, you have the following options:
+   
+   * Option 1: In AWS, create a Lambda function, then attach a SignalFx-hosted layer with a wrapper.
+      * If you are already using Lambda layers, then SignalFx recommends that you follow this option. 
+      * In this option, you will use a Lambda layer created and hosted by SignalFx.
+   * Option 2: In AWS, create a Lambda function, then create and attach a layer based on a SignalFx SAM (Serverless Application Model) template.
+      * If you are already using Lambda layers, then SignalFx also recommends that you follow this option. 
+      * In this option, you will choose a SignalFx template, and then deploy a copy of the layer.
+   * Option 3: Use the wrapper as a regular dependency, and then create a Lambda function based on your artifact containing both code and dependencies.
+   
+For advanced users (to reduce size of deployment packages):
+   * Option 4: Use the wrapper as developer dependency but in production provide it in the layer in the Lambda environment. 
+   This option allows you to conveniently work with the wrapper in the local setting and reduce the size of deployment package at the same time. 
+   It can be achieved by combining information from Options listed above and will not be explained in this README.
+
+### Option 1: Create a Lambda function, then attach the SignalFx-hosted Lambda layer
+
+In this option, you will use a Lambda layer created and hosted by SignalFx.
+
+1. To verify compatibility, review the list of supported regions. See [Lambda Layer Versions](https://github.com/signalfx/lambda-layer-versions/blob/master/nodejs/NODE.md).
+2. Open your AWS console. 
+3. In the landing page, under **Compute**, click **Lambda**.
+4. Click **Create function** to create a layer with SignalFx's capabilities.
+5. Click **Author from scratch**.
+6. In **Function name**, enter a descriptive name for the wrapper. 
+7. In **Runtime**, select the desired language.
+8. Click **Create function**. 
+9. Click on **Layers**, then add a layer.
+10. Mark **Provide a layer version**.
+11. Enter an ARN number. 
+  * To locate the ARN number, see [Lambda Layer Versions](https://github.com/signalfx/lambda-layer-versions/blob/master/nodejs/NODE.md).
+
+### Option 2: Create a Lambda function, then create and attach a layer based on a SignalFx template
+
+In this option, you will choose a SignalFx template, and then deploy a copy of the layer.
+
+1. Open your AWS console. 
+2. In the landing page, under **Compute**, click **Lambda**.
+3. Click **Create function** to create a layer with SignalFx's capabilities.
+4. Click **Browse serverless app repository**.
+5. Click **Public applications**.
+6. In the search field, enter and select **signalfx-lambda-python-wrapper**.
+7. Review the template, permissions, licenses, and then click **Deploy**.
+    * A copy of the layer will now be deployed into your account.
+8. Return to the previous screen to add a layer to the function, select from list of runtime compatible layers, and then select the name of the copy. 
+
+### Option 3: Install the wrapper package with npm
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Run the following installation script in your command line to install latest version of the wrapper:
+
+.. code::
+
+    npm install signalfx-lambda
+    
+Make sure the package is saved to your package.json (never versions of npm do this automatically).
+
+## Step 2: Locate ingest endpoint
+
+By default, this function wrapper will send data to the us0 realm. As a result, if you are not in us0 realm and you want to use the ingest endpoint directly, then you must explicitly set your realm. To set your realm, use a subdomain, such as ingest.us1.signalfx.com or ingest.eu0.signalfx.com.
+
+To locate your realm:
+
+1. Open SignalFx and in the top, right corner, click your profile icon.
+2. Click **My Profile**.
+3. Next to **Organizations**, review the listed realm.
+
+You will use the endpoint to set SIGNALFX_INGEST_ENDPOINT variable in the next step.
+
+## Step 3: Set environment variables
+
+1. Set SIGNALFX_AUTH_TOKEN with your correct access token. Review the following example. 
+
 ```
-{
-  "name": "my-module",
-  "dependencies": {
-    "signalfx-lambda": "^0.0.13"
-  }
-}
+ SIGNALFX_AUTH_TOKEN=signalfx token
+```
+2. Set the ingest endpoint URL (remember to use appropriate realm):
+
+```
+SIGNALFX_INGEST_ENDPOINT=[https://pops.signalfx.com]
+```
+3. Change SIGNALFX_SEND_TIMEOUT (optional):
+```
+SIGNALFX_SEND_TIMEOUT=milliseconds for signalfx client timeout [1000]
 ```
 
+## Step 4: Wrap a function
+      
 Wrap your function handler
 ```
 'use strict';
@@ -40,28 +122,33 @@ exports.handler = signalFxLambda.asyncWrapper(async (event, context) => {
 });
 ```
 
-#### Configuring the ingest endpoint
-
-By default, this function wrapper will send to the `us0` realm. If you are
-not in this realm you will need to set the `SIGNALFX_INGEST_ENDPOINT` environment
-variable to the correct realm ingest endpoint (https://ingest.{REALM}.signalfx.com).
-To determine what realm you are in, check your profile page in the SignalFx
-web application (click the avatar in the upper right and click My Profile).
-
-
-### Environment Variables
+## Step 5: Send custom metrics from a Lambda function (optional)
 
 ```
- SIGNALFX_AUTH_TOKEN=signalfx token
+'use strict';
+
+const signalFxLambda = require('signalfx-lambda');
+
+exports.handler = signalFxLambda.wrapper((event, context, callback) => {
+  ...
+  signalFxLambda.helper.sendGauge('gauge.name', value);
+  callback(null, 'Done');
+});
 ```
 
-Optional parameters available:
+Using async/await
 ```
-SIGNALFX_SEND_TIMEOUT=milliseconds for signalfx client timeout [1000]
+'use strict';
 
-# Change the ingest endpoint URL:
-SIGNALFX_INGEST_ENDPOINT=[https://pops.signalfx.com]
+const signalFxLambda = require('signalfx-lambda');
+
+exports.handler = signalFxLambda.asyncWrapper(async (event, context) => {
+  ...
+  signalFxLambda.helper.sendGauge('gauge.name', value);
+});
 ```
+
+## Additional information
 
 ### Metrics and dimensions sent by the wrapper
 
@@ -89,47 +176,22 @@ The Lambda wrapper adds the following dimensions to all data points sent to Sign
 | function_wrapper_version  | SignalFx function wrapper qualifier (e.g. signalfx-lambda-0.0.9) |
 | metric_source | The literal value of 'lambda_wrapper' |
 
-### Sending a metric from the Lambda function
-
-```
-'use strict';
-
-const signalFxLambda = require('signalfx-lambda');
-
-exports.handler = signalFxLambda.wrapper((event, context, callback) => {
-  ...
-  signalFxLambda.helper.sendGauge('gauge.name', value);
-  callback(null, 'Done');
-});
-```
-
-Using async/await
-```
-'use strict';
-
-const signalFxLambda = require('signalfx-lambda');
-
-exports.handler = signalFxLambda.asyncWrapper(async (event, context) => {
-  ...
-  signalFxLambda.helper.sendGauge('gauge.name', value);
-});
-```
 
 ### Deployment
 
 Run `npm pack` to package the module with the configuration in `package.json`.
 
-## Testing
+### Testing
 
 Install node-lambda via `npm install -g node-lambda` (globally) or `npm install node-lambda` (locally).
 
-### Testing locally
+#### Testing locally
 
 1) Create deploy.env to submit data to SignalFx, containing the required and optional environment variables mentioned above:
 
 2) Run `node-lambda run -f deploy.env`.
 
-## Testing from AWS
+#### Testing from AWS
 
 Run `node-lambda deploy -f deploy.env` to deploy to AWS. It will use any environment variables configured in `.env`. Example:
 
@@ -141,7 +203,7 @@ AWS_HANDLER=index.handler
 AWS_MEMORY_SIZE=128
 AWS_TIMEOUT=3
 AWS_DESCRIPTION=
-AWS_RUNTIME=nodejs6.10 # Use nodejs8.10 when using async/await
+AWS_RUNTIME=nodejs10.x
 AWS_VPC_SUBNETS=
 AWS_VPC_SECURITY_GROUPS=
 AWS_TRACING_CONFIG=
@@ -153,4 +215,4 @@ PACKAGE_DIRECTORY=build
 
 ### License
 
-Apache Software License v2. Copyright © 2014-2017 SignalFx
+Apache Software License v2. Copyright © 2014-2020 SignalFx

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# SignalFx Node Lambda Wrapper
+# SignalFx Node.js Lambda Wrapper
 
 ## Overview 
 
-You can use this document to add a SignalFx wrapper to your AWS Lambda for Node. 
+You can use this document to add a SignalFx wrapper to your AWS Lambda for Node.js. 
 
-The SignalFx Node Lambda Wrapper wraps around an AWS Lambda Node function handler, which allows metrics to be sent to SignalFx.
+The SignalFx Node.js Lambda Wrapper wraps around an AWS Lambda Node.js function handler, which allows metrics to be sent to SignalFx.
 
-At a high-level, to add a SignalFx Node Lambda wrapper, you can package the code yourself, or you can use a Lambda layer containing the wrapper and then attach the layer to a Lambda function.
+At a high-level, to add a SignalFx Node.js Lambda wrapper, you can package the code yourself, or you can use a Lambda layer containing the wrapper and then attach the layer to a Lambda function.
 
 To learn more about Lambda Layers, please visit the AWS documentation site and see [AWS Lambda Layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 
@@ -67,7 +67,7 @@ Run the following installation script in your command line to install latest ver
 
     npm install signalfx-lambda
     
-Make sure the package is saved to your package.json (never versions of npm do this automatically).
+Make sure the package is saved to your package.json (newer versions of npm do this automatically).
 
 ## Step 2: Locate ingest endpoint
 
@@ -172,7 +172,7 @@ The Lambda wrapper adds the following dimensions to all data points sent to Sign
 | aws_function_version  | AWS Function Version |
 | aws_function_qualifier  | AWS Function Version Qualifier (version or version alias if it is not an event source mapping Lambda invocation) |
 | event_source_mappings  | AWS Function Name (if it is an event source mapping Lambda invocation) |
-| aws_execution_env  | AWS execution environment (e.g. AWS_Lambda_nodejs6.10) |
+| aws_execution_env  | AWS execution environment (e.g. AWS_Lambda_nodejs10.x) |
 | function_wrapper_version  | SignalFx function wrapper qualifier (e.g. signalfx-lambda-0.0.9) |
 | metric_source | The literal value of 'lambda_wrapper' |
 


### PR DESCRIPTION
Restructuring nodejs README to have the same structure as python README.