### PR TITLE
Add capability to send Custom Events to SignalFx.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ deploy.env
 build
 node_modules
 *.tgz
+.idea

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ To set your realm, use a subdomain, such as ingest.us1.signalfx.com or ingest.eu
       await signalFxLambda.helper.sendCustomEvent('Custom', {functionName: context.functionName}, {description: 'Custom event'});
             
       // to transform & forward CloudWatch event:
-      await signalFxLambda.helper.sendCloudWatchEvent(event).catch(err => console.log('Event not forwarded to SignalFx!', err));
+      await signalFxLambda.helper.sendCloudWatchEvent(event);
       ...
     });
     ```

--- a/README.md
+++ b/README.md
@@ -96,54 +96,94 @@ To set your realm, use a subdomain, such as ingest.us1.signalfx.com or ingest.eu
 ## Step 4: Wrap a function
       
 1. Wrap your function handler. Review the following example.  
-```
-'use strict';
-
-const signalFxLambda = require('signalfx-lambda');
-
-exports.handler = signalFxLambda.wrapper((event, context, callback) => {
-  ...
-});
-```
+   ```js
+   'use strict';
+   
+   const signalFxLambda = require('signalfx-lambda');
+   
+   exports.handler = signalFxLambda.wrapper((event, context, callback) => {
+   ...
+   });
+   ```
 
 2. Use async/await. Review the following example.  
-```
-'use strict';
-
-const signalFxLambda = require('signalfx-lambda');
-
-exports.handler = signalFxLambda.asyncWrapper(async (event, context) => {
-  ...
-});
-```
+    ```js
+   'use strict';
+   
+   const signalFxLambda = require('signalfx-lambda');
+   
+   exports.handler = signalFxLambda.asyncWrapper(async (event, context) => {
+   ...
+   });
+   ```
 
 ## (Optional) Step 5: Send custom metrics from a Lambda function
 
-1. Wrap your function handler. Review the following example. 
+1. If you use synchronous wrapper, review the following example. 
 
-```
-'use strict';
+    ```js
+    'use strict';
+    
+    const signalFxLambda = require('signalfx-lambda');
+    
+    exports.handler = signalFxLambda.wrapper((event, context, callback) => {
+      ...
+      signalFxLambda.helper.sendGauge('gauge.name', value);
+      callback(null, 'Done');
+    });
+    ```
 
-const signalFxLambda = require('signalfx-lambda');
+2. If you use `async/await`, review the following example. 
+    ```js
+    'use strict';
+    
+    const signalFxLambda = require('signalfx-lambda');
+    
+    exports.handler = signalFxLambda.asyncWrapper(async (event, context) => {
+      ...
+      signalFxLambda.helper.sendGauge('gauge.name', value);
+    });
+    ```
+    
+## (Optional) Step 6: Send custom events or CloudWatch events from a Lambda function
 
-exports.handler = signalFxLambda.wrapper((event, context, callback) => {
-  ...
-  signalFxLambda.helper.sendGauge('gauge.name', value);
-  callback(null, 'Done');
-});
-```
+1. If you use synchronous wrapper, review the following example. 
 
-2. Use `async/await`. Review the following example. 
-```
-'use strict';
+    ```js
+    'use strict';
+    
+    const signalFxLambda = require('signalfx-lambda');
+    
+    exports.handler = signalFxLambda.wrapper((event, context, callback) => {
+      ...
+      // to send custom event:
+      signalFxLambda.helper.sendCustomEvent('Custom', {functionName: context.functionName}, {description: 'Custom event'})
+         .then(() => callback(null, 'Done'));
+      
+      // to transform & forward CloudWatch event:
+      signalFxLambda.helper.sendCloudWatchEvent(event)
+         .then(() => callback(null, 'Done'))
+      
+    });
+    ```
 
-const signalFxLambda = require('signalfx-lambda');
-
-exports.handler = signalFxLambda.asyncWrapper(async (event, context) => {
-  ...
-  signalFxLambda.helper.sendGauge('gauge.name', value);
-});
-```
+2. If you use `async/await`, review the following example. 
+    ```js
+    'use strict';
+    
+    const signalFxLambda = require('signalfx-lambda');
+    
+    exports.handler = signalFxLambda.asyncWrapper(async (event, context) => {
+      ...
+      // to send custom event:
+      await signalFxLambda.helper.sendCustomEvent('Custom', {functionName: context.functionName}, {description: 'Custom event'});
+            
+      // to transform & forward CloudWatch event:
+      await signalFxLambda.helper.sendCloudWatchEvent(event).catch(err => console.log('Event not forwarded to SignalFx!', err));
+      ...
+    });
+    ```
+For additional examples see [sample functions forwarding events to SignalFx](https://github.com/signalfx/cloudwatch-event-forwarder/blob/master/examples).
 
 ## Additional information and optional steps
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx-lambda",
-  "version": "0.0.13",
+  "version": "0.1.0",
   "description": "Node.js lambda wrapper for SignalFx",
   "homepage": "https://signalfx.com",
   "author": {

--- a/signalfx-helper.js
+++ b/signalfx-helper.js
@@ -30,11 +30,12 @@ let defaultDimensions, metricSender;
 let sendPromises = [];
 
 function handleSend(sendPromise){
+  sendPromises.push(sendPromise);
   return sendPromise.catch((err) => {
     if (err) {
       console.error('Could not send data to SignalFx!', err);
     }
-  }).then(() => sendPromises.push(sendPromise));
+  });
 }
 
 function clearSendPromises() {

--- a/signalfx-helper.js
+++ b/signalfx-helper.js
@@ -1,15 +1,18 @@
 'use strict';
 
 const signalfx = require('signalfx');
+const toKeyValueMap = require('./signalfx-transform-helper').toKeyValueMap;
 
-const packageFile = require('./package.json')
+const packageFile = require('./package.json');
 
 const AUTH_TOKEN = process.env.SIGNALFX_AUTH_TOKEN;
 const TIMEOUT_MS = process.env.SIGNALFX_SEND_TIMEOUT;
 
 const INGEST_ENDPOINT = process.env.SIGNALFX_INGEST_ENDPOINT;
 
-var CLIENT_OPTIONS = {};
+const CLOUDWATCH_EVENT_TYPE = 'Cloudwatch';
+
+const CLIENT_OPTIONS = {};
 if (INGEST_ENDPOINT) {
   CLIENT_OPTIONS.ingestEndpoint = INGEST_ENDPOINT
 } else {
@@ -23,9 +26,21 @@ if (!isNaN(timeoutMs)) {
   CLIENT_OPTIONS.timeout = 300;
 }
 
-var defaultDimensions, metricSender;
+const clearSendPromises = () => {
+  sendPromises = [];
+};
 
-var sendPromises = [];
+let defaultDimensions, metricSender;
+
+let sendPromises = [];
+
+function handleSend(sendPromise){
+  return sendPromise.catch((err) => {
+    if (err) {
+      console.error('Could not send data to SignalFx!', err);
+    }
+  }).then(() => sendPromises.push(sendPromise));
+}
 
 function sendMetric(metricName, metricType, metricValue, dimensions={}) {
   var dp = {
@@ -36,22 +51,52 @@ function sendMetric(metricName, metricType, metricValue, dimensions={}) {
   var datapoints = {};
   datapoints[metricType] = [dp];
 
-  var sendPromise = metricSender.send(datapoints).catch((err) => {
-    if (err) {
-      console.log(err);
-    }
-  });
-  sendPromises.push(sendPromise);
-  return sendPromise;
+  return handleSend(metricSender.send(datapoints));
 }
 
-const clearSendPromises = () => {
-  sendPromises = [];
+function sendCustomizedEvent(type, dimensions, properties, timestamp) {
+  let event = {
+    category: 'USER_DEFINED',
+    eventType: type,
+    dimensions: dimensions,
+    properties: properties
+  };
+
+  if (timestamp) {
+    event = Object.assign(event, {timestamp: timestamp});
+  }
+
+  return handleSend(metricSender.sendEvent(event));
+}
+
+function toUnixTime(dateString) {
+  return new Date(dateString).getTime();
+}
+
+function sendCWEvent(cwEvent) {
+  let details, resources;
+
+  try {
+    details = toKeyValueMap({detail: cwEvent.detail});
+    resources = toKeyValueMap({resources: cwEvent.resources});
+  } catch (err) {
+    console.error('Unable to convert details or resources to a key value map. They wont be included in the event.', err);
+  }
+
+  let sfxEvent = {
+    category: 'USER_DEFINED',
+    eventType: CLOUDWATCH_EVENT_TYPE,
+    dimensions: {region: cwEvent.region, account: cwEvent.account, 'detail-type': cwEvent['detail-type'], source: cwEvent.source},
+    properties: Object.assign({id: cwEvent.id, version: cwEvent.version}, details, resources),
+    timestamp: toUnixTime(cwEvent.time)
+  };
+
+  return handleSend(metricSender.sendEvent(sfxEvent));
 }
 
 function setAccessToken(accessToken) {
   metricSender = new signalfx.IngestJson(accessToken || AUTH_TOKEN, CLIENT_OPTIONS);
-} 
+}
 
 module.exports = {
   setAccessToken: setAccessToken,
@@ -92,7 +137,15 @@ module.exports = {
     return sendMetric(metricName, 'counters', metricValue, dimensions);
   },
 
+  sendCustomEvent: function sendCustomEvent(type, dimensions, properties, timestamp) {
+    return sendCustomizedEvent(type, dimensions, properties, timestamp);
+  },
+
+  sendCloudwatchEvent: function sendCloudwatchEvent(cwevent) {
+    return sendCWEvent(cwevent);
+  },
+
   waitForAllSends: function waitForAllSends() {
     return Promise.all(sendPromises).then(clearSendPromises, clearSendPromises);
   }
-}
+};

--- a/signalfx-helper.js
+++ b/signalfx-helper.js
@@ -10,7 +10,7 @@ const TIMEOUT_MS = process.env.SIGNALFX_SEND_TIMEOUT;
 
 const INGEST_ENDPOINT = process.env.SIGNALFX_INGEST_ENDPOINT;
 
-const CLOUDWATCH_EVENT_TYPE = 'Cloudwatch';
+const CLOUDWATCH_EVENT_TYPE = 'CloudWatch';
 
 const CLIENT_OPTIONS = {};
 if (INGEST_ENDPOINT) {
@@ -26,12 +26,7 @@ if (!isNaN(timeoutMs)) {
   CLIENT_OPTIONS.timeout = 300;
 }
 
-const clearSendPromises = () => {
-  sendPromises = [];
-};
-
 let defaultDimensions, metricSender;
-
 let sendPromises = [];
 
 function handleSend(sendPromise){
@@ -40,6 +35,10 @@ function handleSend(sendPromise){
       console.error('Could not send data to SignalFx!', err);
     }
   }).then(() => sendPromises.push(sendPromise));
+}
+
+function clearSendPromises() {
+  sendPromises = [];
 }
 
 function sendMetric(metricName, metricType, metricValue, dimensions={}) {
@@ -54,16 +53,16 @@ function sendMetric(metricName, metricType, metricValue, dimensions={}) {
   return handleSend(metricSender.send(datapoints));
 }
 
-function sendCustomizedEvent(type, dimensions, properties, timestamp) {
+function sendCustomizedEvent(eventType, dimensions, properties, timestamp) {
   let event = {
     category: 'USER_DEFINED',
-    eventType: type,
-    dimensions: dimensions,
-    properties: properties
+    eventType,
+    dimensions,
+    properties,
   };
 
   if (timestamp) {
-    event = Object.assign(event, {timestamp: timestamp});
+    event = Object.assign(event, {timestamp});
   }
 
   return handleSend(metricSender.sendEvent(event));
@@ -86,7 +85,7 @@ function sendCWEvent(cwEvent) {
   let sfxEvent = {
     category: 'USER_DEFINED',
     eventType: CLOUDWATCH_EVENT_TYPE,
-    dimensions: {region: cwEvent.region, account: cwEvent.account, 'detail-type': cwEvent['detail-type'], source: cwEvent.source},
+    dimensions: {region: cwEvent.region, account: cwEvent.account, detailType: cwEvent['detail-type'], source: cwEvent.source},
     properties: Object.assign({id: cwEvent.id, version: cwEvent.version}, details, resources),
     timestamp: toUnixTime(cwEvent.time)
   };
@@ -141,7 +140,7 @@ module.exports = {
     return sendCustomizedEvent(type, dimensions, properties, timestamp);
   },
 
-  sendCloudwatchEvent: function sendCloudwatchEvent(cwevent) {
+  sendCloudWatchEvent: function sendCloudWatchEvent(cwevent) {
     return sendCWEvent(cwevent);
   },
 

--- a/signalfx-helper.js
+++ b/signalfx-helper.js
@@ -58,7 +58,7 @@ function sendCustomizedEvent(eventType, dimensions, properties, timestamp) {
     category: 'USER_DEFINED',
     eventType,
     dimensions,
-    properties,
+    properties
   };
 
   if (timestamp) {

--- a/signalfx-transform-helper.js
+++ b/signalfx-transform-helper.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const FIELD_SEPARATOR = '_';
+const MAX_FIELDNAME_LENGTH = 128;
+
+function isPrimitive(x) {
+  return Object(x) !== x;
+}
+
+function sanitize(name) {
+  return name.replace(/[^a-zA-Z0-9\-_]+/gi, '_').substring(0, MAX_FIELDNAME_LENGTH);
+}
+
+function flatten(obj, newObj, prefix) {
+  for (let entry of Object.entries(obj)) {
+    if (isPrimitive(entry[0]) && isPrimitive(entry[1])) {
+      newObj[sanitize(prefix + entry[0])] = entry[1];
+    } else {
+      flatten(entry[1], newObj,  prefix + entry[0] + FIELD_SEPARATOR);
+    }
+  }
+  return newObj;
+}
+
+function flattenObj(obj) {
+  return flatten(obj, {}, '');
+}
+
+module.exports = {
+  toKeyValueMap: flattenObj
+};

--- a/signalfx-transform-helper.js
+++ b/signalfx-transform-helper.js
@@ -8,15 +8,20 @@ function isPrimitive(x) {
 }
 
 function sanitize(name) {
-  return name.replace(/[^a-zA-Z0-9\-_]+/gi, '_').substring(0, MAX_FIELDNAME_LENGTH);
+  let sanitizedName = name.replace(/[^a-zA-Z0-9\-_]+/gi, '_');
+  if (name.length > MAX_FIELDNAME_LENGTH) {
+    console.warn('Field name ' + name + ' longer than ' + MAX_FIELDNAME_LENGTH + ' will be truncated.');
+    sanitizedName = sanitizedName.substring(0, MAX_FIELDNAME_LENGTH);
+  }
+  return sanitizedName;
 }
 
 function flatten(obj, newObj, prefix) {
-  for (let entry of Object.entries(obj)) {
-    if (isPrimitive(entry[0]) && isPrimitive(entry[1])) {
-      newObj[sanitize(prefix + entry[0])] = entry[1];
+  for (let [key, value] of Object.entries(obj)) {
+    if (isPrimitive(key) && isPrimitive(value)) {
+      newObj[sanitize(prefix + key)] = value;
     } else {
-      flatten(entry[1], newObj,  prefix + entry[0] + FIELD_SEPARATOR);
+      flatten(value, newObj,  prefix + key + FIELD_SEPARATOR);
     }
   }
   return newObj;

--- a/spec/amazonAlert.json
+++ b/spec/amazonAlert.json
@@ -1,0 +1,81 @@
+{
+  "detail": {
+    "notification-type": "ALERT_CREATED",
+    "name": "Scanning bucket policies",
+    "tags": [
+      "Custom_Alert",
+      "Insider"
+    ],
+    "url": "https://lb00.us-east-1.macie.aws.amazon.com/111122223333/posts/alert_id",
+    "alert-arn": "arn:aws:macie:us-east-1:123456789012:trigger/trigger_id/alert/alert_id",
+    "risk-score": 80,
+    "trigger": {
+      "rule-arn": "arn:aws:macie:us-east-1:123456789012:trigger/trigger_id",
+      "alert-type": "basic",
+      "created-at": "2017-01-02 19:54:00.644000",
+      "description": "Alerting on failed enumeration of large number of bucket policies",
+      "risk": 8
+    },
+    "created-at": "2017-04-18T00:21:12.059000",
+    "actor": "555566667777:assumed-role:superawesome:aroaidpldc7nsesfnheji",
+    "summary": {
+      "Description": "Alerting on failed enumeration of large number of bucket policies",
+      "IP": {
+        "34.199.185.34": 121,
+        "34.205.153.2": 2,
+        "72.21.196.70": 2
+      },
+      "Time Range": [
+        {
+          "count": 125,
+          "start": "2017-04-24T20:23:49Z",
+          "end": "2017-04-24T20:25:54Z"
+        }
+      ],
+      "Source ARN": "arn:aws:sts::123456789012:assumed-role/RoleName",
+      "Record Count": 1,
+      "Location": {
+        "us-east-1": 125
+      },
+      "Event Count": 125,
+      "Events": {
+        "GetBucketLocation": {
+          "count": 48,
+          "ISP": {
+            "Amazon": 48
+          }
+        },
+        "ListRoles": {
+          "count": 2,
+          "ISP": {
+            "Amazon": 2
+          }
+        },
+        "GetBucketPolicy": {
+          "count": 37,
+          "ISP": {
+            "Amazon": 37
+          },
+          "Error Code": {
+            "NoSuchBucketPolicy": 22
+          }
+        },
+        "GetBucketAcl": {
+          "count": 37,
+          "ISP": {
+            "Amazon": 37
+          }
+        },
+        "ListBuckets": {
+          "count": 1,
+          "ISP": {
+            "Amazon": 1
+          }
+        }
+      },
+      "recipientAccountId": {
+        "123456789012": 125
+      }
+    }
+  }
+}

--- a/spec/signalfx-helper-spec.js
+++ b/spec/signalfx-helper-spec.js
@@ -1,14 +1,16 @@
 const mock = require('mock-require');
 const sinon = require('sinon');
-const chai = require("chai");
+const chai = require('chai');
 const expect = chai.expect;
 
 // mock signalfx dependency
 const SEND_FUNCTION_STUB = sinon.stub().returns(Promise.resolve());
+const SEND_EVENT_STUB = sinon.stub().returns(Promise.resolve());
 
 class DummyIngestJson {
   constructor() {
     this.send = SEND_FUNCTION_STUB;
+    this.sendEvent = SEND_EVENT_STUB;
   }
 }
 
@@ -18,21 +20,23 @@ mock('signalfx', { IngestJson: DummyIngestJson});
 const signalfxHelper = require('../signalfx-helper');
 
 
-describe("signalfx-helper", () => {
+describe('signalfx-helper', () => {
 
-  const LAMBDA_ARN = "arn:aws:lambda:us-east-2:123456789012:function:test-cw-events";
-  const CONTEXT_DIMENSIONS = {sampleDimension: "test", otherDimension: "otherTest"};
+  const LAMBDA_ARN = 'arn:aws:lambda:us-east-2:123456789012:function:test-cw-events';
+  const CONTEXT_DIMENSIONS = {sampleDimension: 'test', otherDimension: 'otherTest'};
 
   beforeEach(() => {
-    signalfxHelper.setAccessToken("aaaaaaaaaaa");
+    signalfxHelper.setAccessToken('aaaaaaaaaaa');
     signalfxHelper.setLambdaFunctionContext({invokedFunctionArn: LAMBDA_ARN}, CONTEXT_DIMENSIONS);
+    SEND_EVENT_STUB.resetHistory();
+    SEND_FUNCTION_STUB.resetHistory();
   });
 
-  it("should send a counter with correct name, value and dimension", () => {
-    const METRIC_NAME = "sampleMetricName";
+  it('should send a counter with correct name, value and dimension', () => {
+    const METRIC_NAME = 'sampleMetricName';
     const METRIC_VALUE = 10;
 
-    signalfxHelper.sendCounter(METRIC_NAME, METRIC_VALUE, {specificDimension: "addedInTest"});
+    signalfxHelper.sendCounter(METRIC_NAME, METRIC_VALUE, {specificDimension: 'addedInTest'});
     expect(SEND_FUNCTION_STUB.calledOnce).to.be.true;
 
     const firstSentCounter = SEND_FUNCTION_STUB.firstCall.args[0].counters[0];
@@ -44,5 +48,62 @@ describe("signalfx-helper", () => {
     expect(firstSentCounter.dimensions.otherDimension).to.equal('otherTest');
     expect(firstSentCounter.dimensions.lambda_arn).to.equal(LAMBDA_ARN + ':');
   });
+
+  it('should send a custom event with no timestamp', () => {
+    const DIMENSIONS = {dimension: 'one', otherDimension: 'second'};
+    const PROPERTIES = {property: 'prop'};
+    signalfxHelper.sendCustomEvent('testType', DIMENSIONS, PROPERTIES);
+    expect(SEND_EVENT_STUB.calledOnce).to.be.true;
+
+    const event = SEND_EVENT_STUB.firstCall.args[0]
+
+    expect(event.eventType).to.be.equal('testType');
+    expect(event.dimensions).to.be.equal(DIMENSIONS);
+    expect(event.properties).to.be.equal(PROPERTIES);
+    expect(event.category).to.be.equal('USER_DEFINED');
+    expect(event).to.not.have.any.keys('timestamp');
+  });
+
+  it('should send a custom event with timestamp if provided', () => {
+    const DIMENSIONS = {dimension: 'one', otherDimension: 'second'};
+    const PROPERTIES = {property: 'prop'};
+    const TIMESTAMP = 123456;
+    signalfxHelper.sendCustomEvent('testType', DIMENSIONS, PROPERTIES, TIMESTAMP);
+    expect(SEND_EVENT_STUB.calledOnce).to.be.true;
+
+    const event = SEND_EVENT_STUB.firstCall.args[0]
+    expect(event.timestamp).to.be.equal(TIMESTAMP);
+  });
+
+  it('should send a Cloudwatch event with Cloudwatch event type and converted timestamp', () => {
+    const DETAILS = { 'instance-id': 'i-a1s2d3f4g5h6j7', state: 'pending' };
+    const RESOURCES = [ 'arn:aws:ec2:us-east-2:123456789012:instance/i-a1s2d3f4g5h6j7' ];
+
+    const testCwEvent = {
+      version: '0',
+      id: 'abcd1234-a123-b345-c456-d3f4g5h6j7',
+      'detail-type': 'EC2 Instance State-change Notification',
+      source: 'aws.ec2',
+      account: '123456789012',
+      time: '2020-02-20T11:36:21Z',
+      region: 'us-east-2',
+      resources: RESOURCES,
+      detail: DETAILS
+    };
+
+    signalfxHelper.sendCloudwatchEvent(testCwEvent);
+
+    expect(SEND_EVENT_STUB.calledOnce).to.be.true;
+    const event = SEND_EVENT_STUB.firstCall.args[0];
+    expect(event.eventType).to.be.equal('CloudwatchEvent');
+    expect(event.timestamp).to.be.equal(1582198581000);
+    expect(event.properties.id).to.be.equal('abcd1234-a123-b345-c456-d3f4g5h6j7');
+    expect(event.dimensions['detail-type']).to.be.equal('EC2 Instance State-change Notification');
+    expect(event.dimensions.source).to.be.equal('aws.ec2');
+    expect(event.properties['detail_instance-id']).to.be.equal('i-a1s2d3f4g5h6j7');
+    expect(event.properties['detail_state']).to.be.equal('pending');
+    expect(event.properties['resources_0']).to.be.equal('arn:aws:ec2:us-east-2:123456789012:instance/i-a1s2d3f4g5h6j7');
+  });
+
 });
 

--- a/spec/signalfx-helper-spec.js
+++ b/spec/signalfx-helper-spec.js
@@ -91,14 +91,14 @@ describe('signalfx-helper', () => {
       detail: DETAILS
     };
 
-    signalfxHelper.sendCloudwatchEvent(testCwEvent);
+    signalfxHelper.sendCloudWatchEvent(testCwEvent);
 
     expect(SEND_EVENT_STUB.calledOnce).to.be.true;
     const event = SEND_EVENT_STUB.firstCall.args[0];
-    expect(event.eventType).to.be.equal('CloudwatchEvent');
+    expect(event.eventType).to.be.equal('CloudWatch');
     expect(event.timestamp).to.be.equal(1582198581000);
     expect(event.properties.id).to.be.equal('abcd1234-a123-b345-c456-d3f4g5h6j7');
-    expect(event.dimensions['detail-type']).to.be.equal('EC2 Instance State-change Notification');
+    expect(event.dimensions.detailType).to.be.equal('EC2 Instance State-change Notification');
     expect(event.dimensions.source).to.be.equal('aws.ec2');
     expect(event.properties['detail_instance-id']).to.be.equal('i-a1s2d3f4g5h6j7');
     expect(event.properties['detail_state']).to.be.equal('pending');

--- a/spec/signalfx-transform-helper-spec.js
+++ b/spec/signalfx-transform-helper-spec.js
@@ -1,0 +1,82 @@
+const signalfxHelper = require('../signalfx-transform-helper');
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('signalfx-transform-helper', () => {
+
+  it('should leave flat objects as they are', () => {
+    const obj = { 'key1': 'value', 'key2': 5};
+    const flattened = signalfxHelper.toKeyValueMap(obj);
+    expect(flattened.key1).to.be.equal('value');
+    expect(flattened.key2).to.be.equal(5);
+  });
+
+  it('should sanitize field names to include only a-zA-Z0-9-_', () => {
+    const obj = { 'IP Address': "123.45.67.89", 'field': { 'nested/object:name': 'test'}};
+    const flattened = signalfxHelper.toKeyValueMap(obj);
+    expect(flattened.IP_Address).to.equal("123.45.67.89");
+    expect(flattened.field_nested_object_name).to.equal('test');
+  });
+
+  it('should flatten nested properties', () => {
+    const obj = { key: { nestedKey: 'value', otherNestedKey: 'otherValue'}};
+    const flattened = signalfxHelper.toKeyValueMap(obj);
+    expect(flattened['key_nestedKey']).to.be.equal('value');
+    expect(flattened['key_otherNestedKey']).to.be.equal('otherValue');
+  });
+
+  it('should handle different levels of nesting', () => {
+    const obj = {
+      testA: 'a',
+      testB: { testBB: 1},
+      testC: { testCC: {testCCC: 'c', testCCCC: 'cccc'}},
+      testD: { testD: 2, testDD: 'dd'}
+    };
+    const flattened = signalfxHelper.toKeyValueMap(obj);
+    expect(flattened['testA']).to.be.equal('a');
+    expect(flattened['testB_testBB']).to.be.equal(1);
+    expect(flattened['testC_testCC_testCCC']).to.be.equal('c');
+    expect(flattened['testC_testCC_testCCCC']).to.be.equal('cccc');
+    expect(flattened['testD_testD']).to.be.equal(2);
+    expect(flattened['testD_testDD']).to.be.equal('dd');
+  });
+
+  it('should handle arrays', () => {
+    const obj = {
+      resources: ['a', 'b', 'c']
+    };
+    const flattened = signalfxHelper.toKeyValueMap(obj);
+    expect(flattened['resources_0']).to.be.equal('a');
+    expect(flattened['resources_1']).to.be.equal('b');
+    expect(flattened['resources_2']).to.be.equal('c');
+  });
+
+  it('should handle arrays of objects', () => {
+    const obj = {
+      resources: ['a', {b: 'B'}, {c: {c: {c: 'C'}}}, 'd', {e: [1,2,3]}]
+    };
+    const flattened = signalfxHelper.toKeyValueMap(obj);
+    expect(flattened['resources_0']).to.be.equal('a');
+    expect(flattened['resources_1_b']).to.be.equal('B');
+    expect(flattened['resources_2_c_c_c']).to.be.equal('C');
+    expect(flattened['resources_3']).to.be.equal('d');
+    expect(flattened['resources_4_e_0']).to.be.equal(1);
+    expect(flattened['resources_4_e_1']).to.be.equal(2);
+    expect(flattened['resources_4_e_2']).to.be.equal(3);
+  });
+
+  it('should handle sample Amazon event', () => {
+    const event = require('./amazonAlert.json');
+    const flattened = signalfxHelper.toKeyValueMap(event);
+    expect(flattened['detail_risk-score']).to.be.equal(80);
+    expect(flattened['detail_summary_IP_34_199_185_34']).to.be.equal(121);
+    expect(flattened['detail_summary_Time_Range_0_end']).to.be.equal('2017-04-24T20:25:54Z');
+  });
+
+  it('should not include empty fields', () => {
+    const object = { details: {}, resources: [], test: {nested: {}}};
+    const flattened = signalfxHelper.toKeyValueMap(object);
+    expect(flattened).to.be.an('object').that.is.empty;
+  });
+});

--- a/spec/signalfx-transform-helper-spec.js
+++ b/spec/signalfx-transform-helper-spec.js
@@ -8,8 +8,7 @@ describe('signalfx-transform-helper', () => {
   it('should leave flat objects as they are', () => {
     const obj = { 'key1': 'value', 'key2': 5};
     const flattened = signalfxHelper.toKeyValueMap(obj);
-    expect(flattened.key1).to.be.equal('value');
-    expect(flattened.key2).to.be.equal(5);
+    expect(flattened).to.deep.equal(obj);
   });
 
   it('should sanitize field names to include only a-zA-Z0-9-_', () => {


### PR DESCRIPTION
Please note I will update the README in a separate PR, since we have a big changes there to be merged with next release and I want to work on a new version of the README to avoid a merge.

Changes:
1) Expose API to send custom events to SignalFx
2) Add a dedicated helper to send Cloudwatch Events to SignalFx
3) Increase minor version (api changes).

Open questions/ things I would appreciate insight on:
1) is the choice of properties vs dimensions ok?
2) are we aware of any limitations when it comes to the size of the event? 