### PR TITLE
update signalfx core to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "main": "signalfx-lambda",
   "dependencies": {
-    "signalfx": "5.0.0"
+    "signalfx": "^7.0.0"
   },
   "devDependencies": {
     "jasmine": "3.5.0",


### PR DESCRIPTION
My original concern was that this library does not work with Webpack on Linux.

### Issue

1. This library is currently [pinned to signalfx@5.0.0](https://github.com/signalfx/lambda-nodejs/blob/master/package.json#L14).
2. That version of the signalfx core library uses `protobufjs@4`, which was updated [in this commit](https://github.com/signalfx/signalfx-nodejs/commit/4d4c354fce611d4492c11587f1cacfef4033d863#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) due to security warnings.
3. `protobufjs@5` is the version during which [they fixed issues running in Webpack on case-sensitive systems](https://github.com/protobufjs/protobuf.js/wiki/Changes-in-protobuf.js-5.0)
4. This causes this library to be unable to be built in Webpack, primarily only in case-sensitive environments (works locally on MacOS, breaks during the build on Linux).

### Attempted Resolution

The fix appears to have been as simple as upgrading to the current version of `signalfx`, which I have done here. All of the tests are currently passing, and the core library API appears [[1]](https://github.com/signalfx/signalfx-nodejs/blob/54410f6fc07943c6fe4e3a3269485f496a33afd4/lib/client/ingest/signal_fx_client.js#L100) [[2]](https://github.com/signalfx/signalfx-nodejs/blob/54410f6fc07943c6fe4e3a3269485f496a33afd4/lib/client/ingest/signal_fx_client.js#L167) to match the expected API as it's used in this library [[1]](https://github.com/signalfx/lambda-nodejs/blob/75692b736437f68df58fc5ee9f59d2d6465e525f/signalfx-helper.js#L98) [[2]](https://github.com/signalfx/lambda-nodejs/blob/75692b736437f68df58fc5ee9f59d2d6465e525f/signalfx-helper.js#L54) [[3]](https://github.com/signalfx/lambda-nodejs/blob/75692b736437f68df58fc5ee9f59d2d6465e525f/signalfx-helper.js#L69).
