### PR TITLE
We can't use nulls and booleans as dimension values…

### DIFF
--- a/signalfx-transform-helper.js
+++ b/signalfx-transform-helper.js
@@ -19,7 +19,12 @@ function sanitize(name) {
 function extractDetailsForSfx(cwEvent) {
   let detailsMap = {};
   for (let [key, value] of Object.entries(cwEvent.detail)) {
-      detailsMap[sanitize(DETAIL_PREFIX + key)] = isPrimitive(value) ? value : JSON.stringify(value);
+    let sanitizedKey = sanitize(DETAIL_PREFIX + key);
+    if (value == null || typeof value == "boolean" || !isPrimitive(value)) {
+      detailsMap[sanitizedKey] = JSON.stringify(value);
+    } else {
+      detailsMap[sanitizedKey] = value;
+    }
   }
   return detailsMap;
 }

--- a/spec/signalfx-transform-helper-spec.js
+++ b/spec/signalfx-transform-helper-spec.js
@@ -32,22 +32,32 @@ describe('signalfx-transform-helper', () => {
     expect(sanitizedAndPrefixed).to.deep.equal(expected);
   });
 
-  it('should stringify arrays and objects', () => {
+  it('should stringify arrays, objects, nulls and booleans', () => {
     const obj = {
       id: "7bf73129-1428-4cd3-a780-95db273d1602",
       'detail-type': "EC2 Instance State-change Notification",
       detail: {
         key1: 'value',
         key2: 5,
-        key3: {inner1: 42, inner2: 43},
-        key4: [2, "one"]
+        "key2.1": 5.1,
+        key3: {' inner1 ': 42, inner2: null},
+        key4: [2, "one"],
+        key5: [],
+        ' key6 ': ' value space-surrounded ',
+        key7: null,
+        key8: true,
       }
     };
     const expected = {
       detail_key1: 'value',
       detail_key2: 5,
-      detail_key3: '{"inner1":42,"inner2":43}',
-      detail_key4: '[2,"one"]'
+      detail_key2_1: 5.1,
+      detail_key3: '{" inner1 ":42,"inner2":null}',
+      detail_key4: '[2,"one"]',
+      detail_key5: '[]',
+      detail__key6_: ' value space-surrounded ',
+      detail_key7: 'null',
+      detail_key8: 'true',
     };
     const sanitizedAndPrefixed = signalfxHelper.extractDetailsForSfx(obj);
     expect(sanitizedAndPrefixed).to.deep.equal(expected);

--- a/spec/signalfx-transform-helper-spec.js
+++ b/spec/signalfx-transform-helper-spec.js
@@ -46,6 +46,7 @@ describe('signalfx-transform-helper', () => {
         ' key6 ': ' value space-surrounded ',
         key7: null,
         key8: true,
+        key9: new Boolean(false),
       }
     };
     const expected = {
@@ -58,6 +59,7 @@ describe('signalfx-transform-helper', () => {
       detail__key6_: ' value space-surrounded ',
       detail_key7: 'null',
       detail_key8: 'true',
+      detail_key9: 'false',
     };
     const sanitizedAndPrefixed = signalfxHelper.extractDetailsForSfx(obj);
     expect(sanitizedAndPrefixed).to.deep.equal(expected);


### PR DESCRIPTION
... so now stringifying them before sending

Real-life error here: https://splunk.slack.com/archives/CQ17ZQJFP/p1631721432438600?thread_ts=1631715314.417900&cid=CQ17ZQJFP